### PR TITLE
fix: preserve multi-part extensions in mode transforms

### DIFF
--- a/.changeset/fix-module-css-transform.md
+++ b/.changeset/fix-module-css-transform.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/gen-x": patch
+---
+
+Fixed mode transforms incorrectly converting multi-part extensions like `.module.css` to `-module.css`. Export keys now preserve the full extension while transforming only the basename (e.g., `FancyButton.module.css` → `./fancy-button.module.css` with kebab-case mode)

--- a/fixtures/css-assets/package.json
+++ b/fixtures/css-assets/package.json
@@ -9,6 +9,9 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./styles/fancy-button.module.css": {
+      "import": "./dist/styles/FancyButton.module.css"
+    },
     "./styles/reset.css": {
       "import": "./dist/styles/reset.css"
     },

--- a/fixtures/css-assets/package.json.expected
+++ b/fixtures/css-assets/package.json.expected
@@ -9,6 +9,9 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./styles/fancy-button.module.css": {
+      "import": "./dist/styles/FancyButton.module.css"
+    },
     "./styles/reset.css": {
       "import": "./dist/styles/reset.css"
     },

--- a/fixtures/css-assets/src/styles/FancyButton.module.css
+++ b/fixtures/css-assets/src/styles/FancyButton.module.css
@@ -1,0 +1,3 @@
+.button {
+	background: blue;
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import { loadConfig, mergeConfigs } from "./config.js";
 import { generateExports } from "./index.js";
 import type { ReplaceTuples } from "./replace.js";
+import type { TransformMode } from "./transforms/mode.js";
 
 describe("CLI e2e tests with fixtures", () => {
 	const fixturesDir = path.join(process.cwd(), "fixtures");
@@ -13,6 +14,7 @@ describe("CLI e2e tests with fixtures", () => {
 		cliOptions: {
 			customCondition?: string;
 			replace?: ReplaceTuples;
+			mode?: TransformMode;
 		} = {},
 	) {
 		const fixturePath = path.join(fixturesDir, fixtureName);
@@ -295,14 +297,15 @@ describe("CLI e2e tests with fixtures", () => {
 	});
 
 	test("CSS files keep extension in export key", async () => {
-		const { pkg, fixturePath } = await runGenerateExports("css-assets");
+		const { pkg, fixturePath } = await runGenerateExports("css-assets", { mode: "kebab-case" });
 		const expected = await readExpectedPackageJson(fixturePath);
 
 		expect(pkg.exports).toEqual(expected.exports);
 
-		// CSS files should have .css extension in the export key
+		// CSS files should have .css extension in the export key (kebab-cased)
 		expect(pkg.exports).toHaveProperty("./styles/theme.css");
 		expect(pkg.exports).toHaveProperty("./styles/reset.css");
+		expect(pkg.exports).toHaveProperty("./styles/fancy-button.module.css");
 
 		// CSS exports should not have a "types" field, only "import"
 		const themeExport = pkg.exports["./styles/theme.css"];
@@ -310,6 +313,12 @@ describe("CLI e2e tests with fixtures", () => {
 			import: "./dist/styles/theme.css",
 		});
 		expect(themeExport).not.toHaveProperty("types");
+
+		// Module CSS should preserve .module.css extension (not -module.css)
+		const moduleExport = pkg.exports["./styles/fancy-button.module.css"];
+		expect(moduleExport).toEqual({
+			import: "./dist/styles/FancyButton.module.css",
+		});
 	});
 
 	test("CSS files get custom condition for live types", async () => {

--- a/src/make-export-items.ts
+++ b/src/make-export-items.ts
@@ -90,13 +90,30 @@ function makeNameFromFilepath(filepath: string, options: Options): string {
 	const parsed = path.parse(filepath);
 	const isCompilable = COMPILABLE_EXTENSIONS.has(parsed.ext);
 
+	// For non-compilable files, we need to preserve the full extension during transformation
+	// For example: FancyButton.module.css → fancy-button.module.css (not fancy-button-module.css)
+	if (!isCompilable) {
+		const pathWithoutFilename = parsed.dir;
+		// Extract all extensions (e.g., ".module.css" from "FancyButton.module.css")
+		const firstDot = parsed.base.indexOf(".");
+		const basename = firstDot === -1 ? parsed.base : parsed.base.slice(0, firstDot);
+		const allExtensions = firstDot === -1 ? "" : parsed.base.slice(firstDot);
+
+		// 3. replace the path with the replace tuples
+		const replacedPath = replaceName(pathWithoutFilename, options.replace);
+		// 4. transform the path and basename based on the mode
+		const transformedPath = transformFilepathByMode(replacedPath, options.mode);
+		const transformedBasename = transformFilepathByMode(basename, options.mode);
+
+		const fullPath = [transformedPath, transformedBasename].filter(Boolean).join(path.sep);
+		return fullPath + allExtensions;
+	}
+
 	// 1. remove the extension (only for compilable source files)
-	let name = isCompilable
-		? [parsed.dir, parsed.name].filter(Boolean).join(path.sep)
-		: [parsed.dir, parsed.base].filter(Boolean).join(path.sep); // Keep full filename for assets
+	let name = [parsed.dir, parsed.name].filter(Boolean).join(path.sep);
 
 	// 2. flatten index files to directory path (only for compilable files)
-	if (isCompilable && parsed.name === "index") {
+	if (parsed.name === "index") {
 		name = parsed.dir || ".";
 	}
 	// 3. replace the name with the replace tuples


### PR DESCRIPTION
Fixes a bug where mode transformations (kebab-case, camelCase, etc.) would incorrectly convert multi-part file extensions like `.module.css` into `-module.css`.

For example, with kebab-case mode:
- Before: `FancyButton.module.css` → `./styles/fancy-button-module.css`
- After: `FancyButton.module.css` → `./styles/fancy-button.module.css`

The fix extracts all extensions from non-compilable asset files before transformation, transforms only the basename, then reattaches the full extension. Added fixture test to prevent regression .