### PR TITLE
feat: add --sourceOnly flag to emit source-only exports

### DIFF
--- a/.changeset/cold-shrimps-own.md
+++ b/.changeset/cold-shrimps-own.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/gen-x": minor
+---
+
+Add `--sourceOnly` option that emits plain source file paths in the exports map, omitting `import`, `types`, and custom condition entries.

--- a/fixtures/source-only/package.json
+++ b/fixtures/source-only/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@acme/source-only-pkg",
+  "version": "1.0.0",
+  "description": "Package with source-only exports (no import/types)",
+  "type": "module"
+}

--- a/fixtures/source-only/package.json.expected
+++ b/fixtures/source-only/package.json.expected
@@ -1,0 +1,11 @@
+{
+  "name": "@acme/source-only-pkg",
+  "version": "1.0.0",
+  "description": "Package with source-only exports (no import/types)",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./client": "./src/client.ts"
+  }
+}

--- a/fixtures/source-only/src/client.ts
+++ b/fixtures/source-only/src/client.ts
@@ -1,0 +1,1 @@
+export const client = "client";

--- a/fixtures/source-only/src/index.ts
+++ b/fixtures/source-only/src/index.ts
@@ -1,0 +1,1 @@
+export const hello = "world";

--- a/src/build-package-json-exports.ts
+++ b/src/build-package-json-exports.ts
@@ -87,7 +87,7 @@ function buildPackageJsonExports(exportItems: Array<ExportItem>, options?: Optio
 				};
 			}
 
-			acc[name] = entry as ExportEntry;
+			acc[name] = entry;
 
 			return acc;
 		},

--- a/src/build-package-json-exports.ts
+++ b/src/build-package-json-exports.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import type { ExportItem } from "./make-export-items.js";
 
-export type ExportEntry = string | ({ import: string; types: string } & Record<string, string>);
+export type ExportEntry = string | ({ import: string; types?: string } & Record<string, string>);
 export type ExportsField = Record<string, ExportEntry>;
 
 type Options = {
@@ -15,6 +15,12 @@ type Options = {
 	 * @default `dist`
 	 */
 	outputDir?: string;
+	/**
+	 * When true, emit plain string entries pointing directly to source files,
+	 * omitting `import`, `types`, and any custom condition.
+	 * @default false
+	 */
+	sourceOnly?: boolean;
 };
 
 /**
@@ -23,6 +29,7 @@ type Options = {
 function buildPackageJsonExports(exportItems: Array<ExportItem>, options?: Options): ExportsField {
 	const outputDir = options?.outputDir?.trim() || "dist";
 	const customCondition = options?.customCondition?.trim();
+	const sourceOnly = options?.sourceOnly ?? false;
 
 	// Track export keys to detect collisions
 	const exportKeyMap = new Map<string, string>();
@@ -61,18 +68,24 @@ function buildPackageJsonExports(exportItems: Array<ExportItem>, options?: Optio
 			exportKeyMap.set(name, sourcePath);
 
 			// Build export entry
+			// sourceOnly: plain string pointing to source file, no import/types/custom condition
 			// For compilable sources: add import, types
 			// For assets (CSS, etc): only add import (and optional custom condition)
-			const entry = isAsset
-				? {
-						...(customCondition ? { [customCondition]: sourcePath } : {}),
-						import: exportPath,
-					}
-				: {
-						...(customCondition ? { [customCondition]: sourcePath } : {}),
-						import: `${exportPath}.js`,
-						types: `${exportPath}.d.ts`,
-					};
+			let entry: ExportEntry;
+			if (sourceOnly) {
+				entry = sourcePath;
+			} else if (isAsset) {
+				entry = {
+					...(customCondition ? { [customCondition]: sourcePath } : {}),
+					import: exportPath,
+				};
+			} else {
+				entry = {
+					...(customCondition ? { [customCondition]: sourcePath } : {}),
+					import: `${exportPath}.js`,
+					types: `${exportPath}.d.ts`,
+				};
+			}
 
 			acc[name] = entry as ExportEntry;
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -17,6 +17,7 @@ describe("CLI e2e tests with fixtures", () => {
 			customCondition?: string;
 			replace?: ReplaceTuples;
 			mode?: TransformMode;
+			sourceOnly?: boolean;
 		} = {},
 	) {
 		const fixturePath = path.join(fixturesDir, fixtureName);
@@ -50,6 +51,7 @@ describe("CLI e2e tests with fixtures", () => {
 				replace: config.replace,
 				include: config.include,
 				exclude: config.exclude,
+				sourceOnly: config.sourceOnly,
 			});
 
 			// Build the result package.json (simulating what update-package-json does)
@@ -321,6 +323,19 @@ describe("CLI e2e tests with fixtures", () => {
 		expect(moduleExport).toEqual({
 			import: "./dist/styles/FancyButton.module.css",
 		});
+	});
+
+	test("source-only fixture emits plain source paths", async () => {
+		const { pkg, fixturePath } = await runGenerateExports("source-only", {
+			sourceOnly: true,
+		});
+		const expected = await readExpectedPackageJson(fixturePath);
+
+		expect(pkg.exports).toEqual(expected.exports);
+
+		// Verify entries are plain strings (no import/types/custom condition)
+		expect(pkg.exports["."]).toBe("./src/index.ts");
+		expect(pkg.exports["./client"]).toBe("./src/client.ts");
 	});
 
 	test("CSS files get custom condition for live types", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,11 @@ const program = new Command()
 	.option("-o, --output <output>", "The output directory for the package export files", "dist")
 	.option("-p, --package <package>", "The path to the package.json file to read from and write to.", "package.json")
 	.option(
+		"--sourceOnly",
+		"Only emit plain source file paths in exports (no import/types/custom condition pointing to dist/).",
+		false,
+	)
+	.option(
 		`-r, --replace <<pattern${replaceSentinel}replacement>...>`,
 		"Replace export keys, a way to rename exports. Like String.prototype.replace, the pattern is a string or regex, and the replacement is a string. If you want to use a regex pattern, you must use the format /pattern/.",
 		parseReplaceOption,
@@ -63,6 +68,7 @@ async function cli() {
 		mode: "passthrough" as const,
 		replace: [] as ReplaceTuples,
 		customCondition: null as string | null,
+		sourceOnly: false,
 	};
 
 	const config = mergeConfigs(
@@ -74,6 +80,7 @@ async function cli() {
 			mode: options.mode,
 			replace: options.replace,
 			customCondition: options.customCondition?.trim(),
+			sourceOnly: options.sourceOnly,
 		},
 		fileConfig,
 		defaults,
@@ -90,6 +97,7 @@ async function cli() {
 		mode: config.mode,
 		output: config.output,
 		replace: config.replace,
+		sourceOnly: config.sourceOnly,
 	});
 
 	await updatePackageJson({

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,12 @@ export type Config = {
 	 * @default []
 	 */
 	replace?: ReplaceTuples;
+	/**
+	 * When true, emit plain string entries pointing directly to source files,
+	 * omitting `import`, `types`, and any custom condition from the exports map.
+	 * @default false
+	 */
+	sourceOnly?: boolean;
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,13 @@ import { makeExportItems } from "./make-export-items.js";
  * Generate the exports object for the package given the arguments.
  */
 async function generateExports(args: Config): Promise<ExportsField> {
-	const { customCondition, exclude, include, input, output, mode, replace } = parseArguments(args);
+	const { customCondition, exclude, include, input, output, mode, replace, sourceOnly } = parseArguments(args);
 
 	const filepaths = await gatherFilepaths({ input, include, exclude });
 
 	const exportItems = makeExportItems(filepaths, { input, mode, replace });
 
-	const exports = buildPackageJsonExports(exportItems, { outputDir: output, customCondition });
+	const exports = buildPackageJsonExports(exportItems, { outputDir: output, customCondition, sourceOnly });
 
 	return exports;
 }
@@ -42,6 +42,7 @@ function parseArguments(args: Config): Required<Config> {
 	// output: keep relative for package.json
 	const output = args.output?.trim() || "dist";
 	const replace = args.replace ?? [];
+	const sourceOnly = args.sourceOnly ?? false;
 
 	return {
 		customCondition,
@@ -51,5 +52,6 @@ function parseArguments(args: Config): Required<Config> {
 		mode,
 		output,
 		replace,
+		sourceOnly,
 	};
 }


### PR DESCRIPTION
Adds a new `--sourceOnly` CLI flag and config option that generates exports pointing directly to source files as plain strings, omitting the `import`/`types` entries that point to dist/.