### PR TITLE
feat: add --watch mode for automatic exports regeneration

### DIFF
--- a/.changeset/bold-rocks-relate.md
+++ b/.changeset/bold-rocks-relate.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/gen-x": minor
+---
+
+Added `--watch` / `-w` flag to watch the input directory for file changes and automatically regenerate `package.json#exports`. Config is loaded once at startup, and writes are skipped when exports are unchanged, making it efficient for use across many packages in a monorepo.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ This will scan your `src/` directory and generate package.json exports like:
 - ✅ **Replace patterns** - Rename exports with regex or string patterns
 - ✅ **Custom conditions** - For monorepo live types
 - ✅ **Config files** - gen-x.config.{ts,js,json} with type-safe `defineConfig`
+- ✅ **Watch mode** - Automatically regenerate exports on file changes
+- ✅ **Source-only mode** - Emit plain source file paths without import/types conditions
 - ✅ **Cross-platform** - Always generates POSIX paths for package.json
 - ✅ **Collision detection** - Errors on duplicate export keys
 
@@ -109,6 +111,8 @@ Options:
   -o, --output <output>             Output directory (default: "dist")
   -p, --package <package>           Path to package.json (default: "package.json")
   -r, --replace <pattern:=>replacement...>  Replace export keys
+  --sourceOnly                      Only emit plain source file paths in exports
+  -w, --watch                       Watch the input directory for changes and regenerate exports
   -h, --help                        display help for command
 ```
 
@@ -198,6 +202,16 @@ npx gen-x --include "**/*.ts" --include "**/*.tsx"
 # Exclude internal files
 npx gen-x --exclude "**/internal/**" --exclude "**/*.test.*"
 ```
+
+### Watch Mode
+
+Automatically regenerate exports when files are added, deleted, or renamed:
+
+```bash
+npx gen-x --watch
+```
+
+Config is loaded once at startup and reused on every regeneration, so there is no repeated overhead from esbuild transforms. Writes are skipped when exports haven't changed, avoiding unnecessary downstream rebuilds in tools like Turborepo.
 
 ## API Usage
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,12 @@ async function cli() {
 
 	// Watch mode: run an initial generation, then watch for file changes indefinitely.
 	// Config is loaded once above and reused on every regeneration to avoid repeated esbuild transforms.
+	if (options.watch && options.dryRun) {
+		console.error("Error: --dry-run is not supported in --watch mode. Remove --dry-run or disable --watch.");
+		process.exitCode = 1;
+		return;
+	}
+
 	if (options.watch) {
 		await watch({ config, packageJsonPath });
 		return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,33 +88,18 @@ async function cli() {
 		defaults,
 	);
 
-	const dryRun = Boolean(options.dryRun);
-	const watchMode = Boolean(options.watch);
 	const packageJsonPath = options.package?.trim() || "package.json";
 
-	const resolvedConfig = {
-		customCondition: config.customCondition,
-		exclude: config.exclude,
-		include: config.include,
-		input: config.input,
-		mode: config.mode,
-		output: config.output,
-		replace: config.replace,
-		sourceOnly: config.sourceOnly,
-	};
-
-	if (watchMode) {
-		await watch({ config: resolvedConfig, packageJsonPath });
+	// Watch mode: run an initial generation, then watch for file changes indefinitely.
+	// Config is loaded once above and reused on every regeneration to avoid repeated esbuild transforms.
+	if (options.watch) {
+		await watch({ config, packageJsonPath });
 		return;
 	}
 
-	const exports = await generateExports(resolvedConfig);
-
-	await updatePackageJson({
-		dryRun,
-		exports,
-		packageJsonPath,
-	});
+	// One-shot mode: generate exports and write (or preview with --dry-run).
+	const exports = await generateExports(config);
+	await updatePackageJson({ dryRun: Boolean(options.dryRun), exports, packageJsonPath });
 }
 
 void (await cli());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { parseGlobOption } from "./parse-glob-option.js";
 import { parseReplaceOption, replaceSentinel, type ReplaceTuples } from "./replace.js";
 import { transformMode, transformModes } from "./transforms/mode.js";
 import { updatePackageJson } from "./update-package-json.js";
+import { watch } from "./watch.js";
 
 const packageName = pkg.name;
 const packageVersion = pkg.version;
@@ -18,6 +19,7 @@ const program = new Command()
 	.name(packageName)
 	.version(packageVersion)
 	.option("--dry-run, --dryRun", "Preview changes to standard out for debugging.", false)
+	.option("-w, --watch", "Watch the input directory for changes and regenerate exports.", false)
 	.option("--exclude <exclude...>", "A list of globs to exclude file paths from.", [
 		"**/*.d.ts",
 		"**/*.test.*",
@@ -87,9 +89,10 @@ async function cli() {
 	);
 
 	const dryRun = Boolean(options.dryRun);
+	const watchMode = Boolean(options.watch);
 	const packageJsonPath = options.package?.trim() || "package.json";
 
-	const exports = await generateExports({
+	const resolvedConfig = {
 		customCondition: config.customCondition,
 		exclude: config.exclude,
 		include: config.include,
@@ -98,7 +101,14 @@ async function cli() {
 		output: config.output,
 		replace: config.replace,
 		sourceOnly: config.sourceOnly,
-	});
+	};
+
+	if (watchMode) {
+		await watch({ config: resolvedConfig, packageJsonPath });
+		return;
+	}
+
+	const exports = await generateExports(resolvedConfig);
 
 	await updatePackageJson({
 		dryRun,

--- a/src/watch.test.ts
+++ b/src/watch.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { startWatch, type WatchHandle } from "./watch.js";
+import { startWatch } from "./watch.js";
 
 function waitForFileChange(filePath: string, expected: (pkg: Record<string, unknown>) => boolean): Promise<void> {
 	return new Promise((resolve, reject) => {
@@ -33,12 +33,13 @@ describe("watch mode", () => {
 	let tmpDir: string;
 	let srcDir: string;
 	let packageJsonPath: string;
-	let handle: WatchHandle | null = null;
+	let ac: AbortController;
 
 	beforeEach(async () => {
 		tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gen-x-watch-"));
 		srcDir = path.join(tmpDir, "src");
 		packageJsonPath = path.join(tmpDir, "package.json");
+		ac = new AbortController();
 
 		await fsPromises.mkdir(srcDir, { recursive: true });
 		await fsPromises.writeFile(path.join(srcDir, "index.ts"), "export const x = 1;");
@@ -46,15 +47,15 @@ describe("watch mode", () => {
 	});
 
 	afterEach(async () => {
-		handle?.close();
-		handle = null;
+		ac.abort();
 		await fsPromises.rm(tmpDir, { recursive: true, force: true });
 	});
 
 	test("initial run generates exports", async () => {
-		handle = await startWatch({
+		await startWatch({
 			config: { input: srcDir },
 			packageJsonPath,
+			signal: ac.signal,
 		});
 
 		const content = await fsPromises.readFile(packageJsonPath, "utf8");
@@ -70,9 +71,10 @@ describe("watch mode", () => {
 	});
 
 	test("regenerates exports when a file is added", async () => {
-		handle = await startWatch({
+		await startWatch({
 			config: { input: srcDir },
 			packageJsonPath,
+			signal: ac.signal,
 		});
 
 		const waiting = waitForFileChange(packageJsonPath, (pkg) => {
@@ -103,9 +105,10 @@ describe("watch mode", () => {
 	test("regenerates exports when a file is deleted", async () => {
 		await fsPromises.writeFile(path.join(srcDir, "utils.ts"), "export const y = 2;");
 
-		handle = await startWatch({
+		await startWatch({
 			config: { input: srcDir },
 			packageJsonPath,
+			signal: ac.signal,
 		});
 
 		// Verify utils is in initial exports
@@ -135,9 +138,10 @@ describe("watch mode", () => {
 	});
 
 	test("skips write when exports are unchanged", async () => {
-		handle = await startWatch({
+		await startWatch({
 			config: { input: srcDir },
 			packageJsonPath,
+			signal: ac.signal,
 		});
 
 		const { mtimeMs: initialMtime } = await fsPromises.stat(packageJsonPath);

--- a/src/watch.test.ts
+++ b/src/watch.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { startWatch, type WatchHandle } from "./watch.js";
+
+function waitForFileChange(filePath: string, expected: (pkg: Record<string, unknown>) => boolean): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			watcher.close();
+			reject(new Error("Timed out waiting for package.json to update"));
+		}, 5_000);
+
+		const watcher = fs.watch(filePath, async () => {
+			try {
+				const content = await fsPromises.readFile(filePath, "utf8");
+				const pkg = JSON.parse(content) as Record<string, unknown>;
+				if (expected(pkg)) {
+					clearTimeout(timeout);
+					watcher.close();
+					resolve();
+				}
+			} catch {
+				// file may be mid-write, ignore and wait for next event
+			}
+		});
+	});
+}
+
+describe("watch mode", () => {
+	let tmpDir: string;
+	let srcDir: string;
+	let packageJsonPath: string;
+	let handle: WatchHandle | null = null;
+
+	beforeEach(async () => {
+		tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "gen-x-watch-"));
+		srcDir = path.join(tmpDir, "src");
+		packageJsonPath = path.join(tmpDir, "package.json");
+
+		await fsPromises.mkdir(srcDir, { recursive: true });
+		await fsPromises.writeFile(path.join(srcDir, "index.ts"), "export const x = 1;");
+		await fsPromises.writeFile(packageJsonPath, JSON.stringify({ name: "test-pkg", version: "1.0.0" }, null, 2) + "\n");
+	});
+
+	afterEach(async () => {
+		handle?.close();
+		handle = null;
+		await fsPromises.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test("initial run generates exports", async () => {
+		handle = await startWatch({
+			config: { input: srcDir },
+			packageJsonPath,
+		});
+
+		const content = await fsPromises.readFile(packageJsonPath, "utf8");
+		const pkg = JSON.parse(content);
+
+		expect(pkg.exports).toEqual({
+			"./package.json": "./package.json",
+			".": {
+				import: "./dist/index.js",
+				types: "./dist/index.d.ts",
+			},
+		});
+	});
+
+	test("regenerates exports when a file is added", async () => {
+		handle = await startWatch({
+			config: { input: srcDir },
+			packageJsonPath,
+		});
+
+		const waiting = waitForFileChange(packageJsonPath, (pkg) => {
+			const exports = pkg.exports as Record<string, unknown> | undefined;
+			return exports != null && "./utils" in exports;
+		});
+
+		await fsPromises.writeFile(path.join(srcDir, "utils.ts"), "export const y = 2;");
+
+		await waiting;
+
+		const content = await fsPromises.readFile(packageJsonPath, "utf8");
+		const pkg = JSON.parse(content);
+
+		expect(pkg.exports).toEqual({
+			"./package.json": "./package.json",
+			".": {
+				import: "./dist/index.js",
+				types: "./dist/index.d.ts",
+			},
+			"./utils": {
+				import: "./dist/utils.js",
+				types: "./dist/utils.d.ts",
+			},
+		});
+	});
+
+	test("regenerates exports when a file is deleted", async () => {
+		await fsPromises.writeFile(path.join(srcDir, "utils.ts"), "export const y = 2;");
+
+		handle = await startWatch({
+			config: { input: srcDir },
+			packageJsonPath,
+		});
+
+		// Verify utils is in initial exports
+		let content = await fsPromises.readFile(packageJsonPath, "utf8");
+		let pkg = JSON.parse(content);
+		expect(pkg.exports).toHaveProperty("./utils");
+
+		const waiting = waitForFileChange(packageJsonPath, (pkg) => {
+			const exports = pkg.exports as Record<string, unknown> | undefined;
+			return exports != null && !("./utils" in exports);
+		});
+
+		await fsPromises.unlink(path.join(srcDir, "utils.ts"));
+
+		await waiting;
+
+		content = await fsPromises.readFile(packageJsonPath, "utf8");
+		pkg = JSON.parse(content);
+
+		expect(pkg.exports).toEqual({
+			"./package.json": "./package.json",
+			".": {
+				import: "./dist/index.js",
+				types: "./dist/index.d.ts",
+			},
+		});
+	});
+
+	test("skips write when exports are unchanged", async () => {
+		handle = await startWatch({
+			config: { input: srcDir },
+			packageJsonPath,
+		});
+
+		const { mtimeMs: initialMtime } = await fsPromises.stat(packageJsonPath);
+
+		// Modify file content (not structure) — should not trigger a write
+		await fsPromises.writeFile(path.join(srcDir, "index.ts"), "export const x = 999;");
+
+		// Wait longer than debounce + regeneration
+		await new Promise((resolve) => setTimeout(resolve, 500));
+
+		const { mtimeMs: afterMtime } = await fsPromises.stat(packageJsonPath);
+		expect(afterMtime).toBe(initialMtime);
+	});
+});

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { Config } from "./config.js";
+
+import { generateExports } from "./index.js";
+import { updatePackageJson } from "./update-package-json.js";
+
+type WatchOptions = {
+	config: Config;
+	packageJsonPath: string;
+};
+
+async function watch({ config, packageJsonPath }: WatchOptions): Promise<void> {
+	const inputDir = path.resolve(config.input?.trim() || "src");
+	let previousExportsJson = "";
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	async function regenerate() {
+		try {
+			const exports = await generateExports(config);
+			const exportsJson = JSON.stringify(exports);
+
+			if (exportsJson === previousExportsJson) {
+				return;
+			}
+
+			previousExportsJson = exportsJson;
+
+			await updatePackageJson({
+				dryRun: false,
+				exports,
+				packageJsonPath,
+			});
+		} catch (error) {
+			console.error("gen-x watch error:", error);
+		}
+	}
+
+	await regenerate();
+
+	const watcher = fs.watch(inputDir, { recursive: true }, () => {
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+		}
+		debounceTimer = setTimeout(() => {
+			void regenerate();
+		}, 200);
+	});
+
+	console.log(`Watching ${inputDir} for changes...`);
+
+	process.on("SIGINT", () => {
+		watcher.close();
+		process.exit(0);
+	});
+
+	process.on("SIGTERM", () => {
+		watcher.close();
+		process.exit(0);
+	});
+
+	await new Promise(() => {});
+}
+
+export {
+	//,
+	watch,
+};

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -18,12 +18,21 @@ type WatchOptions = {
 	packageJsonPath: string;
 };
 
+type WatchHandle = {
+	/**
+	 * Stop watching and clean up the file watcher.
+	 */
+	close: () => void;
+};
+
 /**
- * Watch the input directory for file changes and regenerate package.json#exports
- * automatically. Runs an initial generation, then blocks indefinitely until the
- * process is terminated via SIGINT or SIGTERM.
+ * Start watching the input directory for file changes and regenerate
+ * package.json#exports automatically. Runs an initial generation, then
+ * watches for subsequent changes.
+ *
+ * Returns a handle that can be used to stop the watcher.
  */
-async function watch({ config, packageJsonPath }: WatchOptions): Promise<void> {
+async function startWatch({ config, packageJsonPath }: WatchOptions): Promise<WatchHandle> {
 	const inputDir = path.resolve(config.input?.trim() || "src");
 	let previousExportsJson = "";
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -68,14 +77,32 @@ async function watch({ config, packageJsonPath }: WatchOptions): Promise<void> {
 
 	console.log(`Watching ${inputDir} for changes...`);
 
+	return {
+		close() {
+			if (debounceTimer) {
+				clearTimeout(debounceTimer);
+			}
+			watcher.close();
+		},
+	};
+}
+
+/**
+ * Watch the input directory for file changes and regenerate package.json#exports
+ * automatically. Runs an initial generation, then blocks indefinitely until the
+ * process is terminated via SIGINT or SIGTERM.
+ */
+async function watch(options: WatchOptions): Promise<void> {
+	const handle = await startWatch(options);
+
 	// Close the watcher on process termination to release the file handle cleanly.
 	process.on("SIGINT", () => {
-		watcher.close();
+		handle.close();
 		process.exit(0);
 	});
 
 	process.on("SIGTERM", () => {
-		watcher.close();
+		handle.close();
 		process.exit(0);
 	});
 
@@ -86,5 +113,12 @@ async function watch({ config, packageJsonPath }: WatchOptions): Promise<void> {
 
 export {
 	//,
+	startWatch,
 	watch,
+};
+
+export type {
+	//,
+	WatchHandle,
+	WatchOptions,
 };

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -7,15 +7,31 @@ import { generateExports } from "./index.js";
 import { updatePackageJson } from "./update-package-json.js";
 
 type WatchOptions = {
+	/**
+	 * The resolved gen-x configuration. Loaded once at startup to avoid
+	 * repeated esbuild transforms on every file change.
+	 */
 	config: Config;
+	/**
+	 * The path to the package.json file to write exports to.
+	 */
 	packageJsonPath: string;
 };
 
+/**
+ * Watch the input directory for file changes and regenerate package.json#exports
+ * automatically. Runs an initial generation, then blocks indefinitely until the
+ * process is terminated via SIGINT or SIGTERM.
+ */
 async function watch({ config, packageJsonPath }: WatchOptions): Promise<void> {
 	const inputDir = path.resolve(config.input?.trim() || "src");
 	let previousExportsJson = "";
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+	/**
+	 * Re-run the exports pipeline and write to package.json.
+	 * Skips the write if the exports object is unchanged from the previous run.
+	 */
 	async function regenerate() {
 		try {
 			const exports = await generateExports(config);
@@ -39,6 +55,8 @@ async function watch({ config, packageJsonPath }: WatchOptions): Promise<void> {
 
 	await regenerate();
 
+	// Recursively watch the input directory for any filesystem events (add, delete, rename).
+	// Events are debounced to 200ms to batch rapid changes (e.g., renames emit multiple events).
 	const watcher = fs.watch(inputDir, { recursive: true }, () => {
 		if (debounceTimer) {
 			clearTimeout(debounceTimer);
@@ -50,6 +68,7 @@ async function watch({ config, packageJsonPath }: WatchOptions): Promise<void> {
 
 	console.log(`Watching ${inputDir} for changes...`);
 
+	// Close the watcher on process termination to release the file handle cleanly.
 	process.on("SIGINT", () => {
 		watcher.close();
 		process.exit(0);
@@ -60,7 +79,9 @@ async function watch({ config, packageJsonPath }: WatchOptions): Promise<void> {
 		process.exit(0);
 	});
 
-	await new Promise(() => {});
+	// Block forever so the process stays alive while fs.watch runs.
+	// Signal handlers above ensure clean shutdown on SIGINT/SIGTERM.
+	await new Promise<never>(() => {});
 }
 
 export {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -16,13 +16,11 @@ type WatchOptions = {
 	 * The path to the package.json file to write exports to.
 	 */
 	packageJsonPath: string;
-};
-
-type WatchHandle = {
 	/**
-	 * Stop watching and clean up the file watcher.
+	 * An AbortSignal to stop watching and clean up the file watcher.
+	 * Similar to a React useEffect cleanup function.
 	 */
-	close: () => void;
+	signal?: AbortSignal;
 };
 
 /**
@@ -30,18 +28,29 @@ type WatchHandle = {
  * package.json#exports automatically. Runs an initial generation, then
  * watches for subsequent changes.
  *
- * Returns a handle that can be used to stop the watcher.
+ * Pass an AbortSignal to stop watching. The signal is forwarded to
+ * `fs.watch`, which closes the watcher when aborted.
  */
-async function startWatch({ config, packageJsonPath }: WatchOptions): Promise<WatchHandle> {
+async function startWatch({ config, packageJsonPath, signal }: WatchOptions): Promise<void> {
 	const inputDir = path.resolve(config.input?.trim() || "src");
 	let previousExportsJson = "";
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let running = false;
+	let pending = false;
 
 	/**
 	 * Re-run the exports pipeline and write to package.json.
 	 * Skips the write if the exports object is unchanged from the previous run.
+	 * Guarded so only one regeneration runs at a time; if a change arrives
+	 * while one is in-flight, exactly one follow-up run is scheduled.
 	 */
 	async function regenerate() {
+		if (running) {
+			pending = true;
+			return;
+		}
+
+		running = true;
 		try {
 			const exports = await generateExports(config);
 			const exportsJson = JSON.stringify(exports);
@@ -59,6 +68,12 @@ async function startWatch({ config, packageJsonPath }: WatchOptions): Promise<Wa
 			});
 		} catch (error) {
 			console.error("gen-x watch error:", error);
+		} finally {
+			running = false;
+			if (pending) {
+				pending = false;
+				void regenerate();
+			}
 		}
 	}
 
@@ -66,7 +81,8 @@ async function startWatch({ config, packageJsonPath }: WatchOptions): Promise<Wa
 
 	// Recursively watch the input directory for any filesystem events (add, delete, rename).
 	// Events are debounced to 200ms to batch rapid changes (e.g., renames emit multiple events).
-	const watcher = fs.watch(inputDir, { recursive: true }, () => {
+	// The AbortSignal is forwarded to fs.watch, which closes the watcher when aborted.
+	fs.watch(inputDir, { recursive: true, signal }, () => {
 		if (debounceTimer) {
 			clearTimeout(debounceTimer);
 		}
@@ -76,15 +92,6 @@ async function startWatch({ config, packageJsonPath }: WatchOptions): Promise<Wa
 	});
 
 	console.log(`Watching ${inputDir} for changes...`);
-
-	return {
-		close() {
-			if (debounceTimer) {
-				clearTimeout(debounceTimer);
-			}
-			watcher.close();
-		},
-	};
 }
 
 /**
@@ -92,19 +99,21 @@ async function startWatch({ config, packageJsonPath }: WatchOptions): Promise<Wa
  * automatically. Runs an initial generation, then blocks indefinitely until the
  * process is terminated via SIGINT or SIGTERM.
  */
-async function watch(options: WatchOptions): Promise<void> {
-	const handle = await startWatch(options);
+async function watch(options: Omit<WatchOptions, "signal">): Promise<void> {
+	const abortController = new AbortController();
 
 	// Close the watcher on process termination to release the file handle cleanly.
 	process.on("SIGINT", () => {
-		handle.close();
+		abortController.abort();
 		process.exit(0);
 	});
 
 	process.on("SIGTERM", () => {
-		handle.close();
+		abortController.abort();
 		process.exit(0);
 	});
+
+	await startWatch({ ...options, signal: abortController.signal });
 
 	// Block forever so the process stays alive while fs.watch runs.
 	// Signal handlers above ensure clean shutdown on SIGINT/SIGTERM.
@@ -119,6 +128,5 @@ export {
 
 export type {
 	//,
-	WatchHandle,
 	WatchOptions,
 };


### PR DESCRIPTION
Watch the input directory for file changes and regenerate package.json#exports automatically. Config is loaded once at startup to avoid repeated esbuild transforms. Writes are skipped when exports haven't changed.