### PR TITLE
fix: write package.json atomically to prevent truncated reads

### DIFF
--- a/.changeset/atomic-package-json-write.md
+++ b/.changeset/atomic-package-json-write.md
@@ -1,0 +1,5 @@
+---
+"@ngrok/gen-x": patch
+---
+
+Write package.json atomically (write to a temp file, then rename) instead of truncating it in place. Previously a concurrent reader — e.g. a bundler resolving the package mid-build, or a build tool capturing task outputs — could observe an empty or partially-written package.json. The write resolves symlinks so a symlinked package.json is still written through to its target, preserves the original file's permissions, and cleans up its temp file on failure.

--- a/src/update-package-json.test.ts
+++ b/src/update-package-json.test.ts
@@ -2,7 +2,7 @@ import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { updatePackageJson } from "./update-package-json.js";
 
@@ -74,5 +74,127 @@ describe("updatePackageJson", () => {
 
 		const content = await fsPromises.readFile(packageJsonPath, "utf8");
 		expect(content.endsWith("\n")).toBe(true);
+	});
+
+	test("does not leave temp files behind after a successful write", async () => {
+		const original = { name: "my-pkg" };
+		await fsPromises.writeFile(packageJsonPath, JSON.stringify(original, null, 2) + "\n");
+
+		await updatePackageJson({ packageJsonPath, exports: { ".": "./index.js" } });
+
+		const entries = await fsPromises.readdir(tmpDir);
+		expect(entries).toEqual(["package.json"]);
+	});
+
+	// skipped on Windows: replacing a file that has concurrent open handles is
+	// not atomic there, so the reader loop can flake even with a correct implementation
+	test.skipIf(process.platform === "win32")(
+		"concurrent readers never observe an empty or partial package.json",
+		async () => {
+			const original = { name: "my-pkg", version: "1.0.0" };
+			await fsPromises.writeFile(packageJsonPath, JSON.stringify(original, null, 2) + "\n");
+
+			// hammer the file with reads while updates are in flight; with a
+			// truncate-then-write the reader can catch the empty window, with an
+			// atomic rename it only ever sees complete old or new contents
+			const state = { stop: false };
+			const reader = (async () => {
+				while (!state.stop) {
+					const content = await fsPromises.readFile(packageJsonPath, "utf8");
+					expect(content.length).toBeGreaterThan(0);
+					expect(() => JSON.parse(content)).not.toThrow();
+				}
+			})();
+			// mark an early reader failure as handled so it can't surface as an
+			// unhandled rejection; the `await reader` below still rethrows it
+			reader.catch(() => {});
+
+			try {
+				for (let i = 0; i < 50; i++) {
+					await updatePackageJson({ packageJsonPath, exports: { ".": `./index-${i}.js` } });
+				}
+			} finally {
+				state.stop = true;
+			}
+			await reader;
+		},
+	);
+
+	test("dry run leaves the file untouched and writes nothing", async () => {
+		const originalContent = JSON.stringify({ name: "my-pkg" }, null, 2) + "\n";
+		await fsPromises.writeFile(packageJsonPath, originalContent);
+
+		await updatePackageJson({ packageJsonPath, dryRun: true, exports: { ".": "./index.js" } });
+
+		expect(await fsPromises.readFile(packageJsonPath, "utf8")).toBe(originalContent);
+		expect(await fsPromises.readdir(tmpDir)).toEqual(["package.json"]);
+	});
+
+	test.skipIf(process.platform === "win32")("writes through a symlinked package.json", async () => {
+		const realPath = path.join(tmpDir, "real-package.json");
+		await fsPromises.writeFile(realPath, JSON.stringify({ name: "my-pkg" }, null, 2) + "\n");
+		await fsPromises.symlink(realPath, packageJsonPath);
+
+		await updatePackageJson({ packageJsonPath, exports: { ".": "./index.js" } });
+
+		// the symlink is preserved and the real file received the update
+		const linkStats = await fsPromises.lstat(packageJsonPath);
+		expect(linkStats.isSymbolicLink()).toBe(true);
+		const content = JSON.parse(await fsPromises.readFile(realPath, "utf8"));
+		expect(content.exports).toEqual({ ".": "./index.js" });
+	});
+
+	test.skipIf(process.platform === "win32")("preserves the original file's permissions", async () => {
+		const original = { name: "my-pkg" };
+		await fsPromises.writeFile(packageJsonPath, JSON.stringify(original, null, 2) + "\n");
+		await fsPromises.chmod(packageJsonPath, 0o600);
+
+		await updatePackageJson({ packageJsonPath, exports: { ".": "./index.js" } });
+
+		const stats = await fsPromises.stat(packageJsonPath);
+		expect(stats.mode & 0o777).toBe(0o600);
+	});
+
+	test.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+		"leaves the original untouched when the directory is not writable",
+		async () => {
+			const original = { name: "my-pkg" };
+			await fsPromises.writeFile(packageJsonPath, JSON.stringify(original, null, 2) + "\n");
+
+			// make the directory read-only so creating the temp file fails
+			await fsPromises.chmod(tmpDir, 0o555);
+			try {
+				await expect(updatePackageJson({ packageJsonPath, exports: { ".": "./index.js" } })).rejects.toThrow();
+			} finally {
+				await fsPromises.chmod(tmpDir, 0o755);
+			}
+
+			// the original file is untouched and no temp files are left behind
+			const entries = await fsPromises.readdir(tmpDir);
+			expect(entries).toEqual(["package.json"]);
+			const content = await fsPromises.readFile(packageJsonPath, "utf8");
+			expect(JSON.parse(content)).toEqual(original);
+		},
+	);
+
+	test("cleans up the temp file when the rename fails", async () => {
+		const original = { name: "my-pkg" };
+		await fsPromises.writeFile(packageJsonPath, JSON.stringify(original, null, 2) + "\n");
+
+		// fail after the temp file has been written so the cleanup path runs
+		const renameSpy = vi.spyOn(fsPromises, "rename").mockRejectedValueOnce(new Error("EACCES: rename failed"));
+		try {
+			await expect(updatePackageJson({ packageJsonPath, exports: { ".": "./index.js" } })).rejects.toThrow(
+				"rename failed",
+			);
+		} finally {
+			renameSpy.mockRestore();
+		}
+
+		// the temp file was cleaned up and the original file is untouched
+		const entries = await fsPromises.readdir(tmpDir);
+		expect(entries).toEqual(["package.json"]);
+		const content = await fsPromises.readFile(packageJsonPath, "utf8");
+		expect(JSON.parse(content)).toEqual(original);
 	});
 });

--- a/src/update-package-json.ts
+++ b/src/update-package-json.ts
@@ -1,4 +1,6 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
 
 import type { ExportsField } from "./build-package-json-exports.js";
 
@@ -25,11 +27,14 @@ type Args = {
  */
 async function updatePackageJson({ dryRun = false, exports, packageJsonPath }: Args) {
 	let originalPackageJsonFile: string;
+	let originalStats: Awaited<ReturnType<typeof fs.stat>>;
 	let originalPackageJson: Record<string, unknown>;
 
-	// read the package.json file
+	// read the package.json file (and its stats, so the atomic write below can
+	// preserve the original file's permissions)
 	try {
 		originalPackageJsonFile = await fs.readFile(packageJsonPath, "utf8");
+		originalStats = await fs.stat(packageJsonPath);
 	} catch (error) {
 		console.error(`Failed to read package.json at ${packageJsonPath}`);
 		throw error;
@@ -68,10 +73,42 @@ async function updatePackageJson({ dryRun = false, exports, packageJsonPath }: A
 	}
 	data += eofNewline;
 
-	// write the updated package.json file
+	// write the updated package.json file atomically: write to a unique temp
+	// file in the same directory, then rename it over package.json. A plain
+	// writeFile truncates the file before writing, so a concurrent reader
+	// (e.g. a bundler resolving the package mid-build) can observe an empty
+	// or partial package.json. rename is atomic on the same filesystem, so
+	// readers only ever see the old contents or the new contents.
+	let tempPath: string | undefined;
 	try {
-		await fs.writeFile(packageJsonPath, data, "utf8");
+		// resolve symlinks so the write goes through to the real file (a rename
+		// onto the symlink's own path would replace the link instead) and so the
+		// temp file lands on the same filesystem, keeping the rename atomic
+		const realPath = await fs.realpath(packageJsonPath);
+		tempPath = path.join(
+			path.dirname(realPath),
+			`.${path.basename(realPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`,
+		);
+
+		const tempFile = await fs.open(tempPath, "w");
+		try {
+			await tempFile.writeFile(data, "utf8");
+			// preserve the original file's permissions; a fresh temp file would
+			// otherwise reset them to the process default (0o666 & ~umask)
+			await tempFile.chmod(originalStats.mode);
+			// flush to disk before the rename so a crash can't persist the rename
+			// ahead of the file data, which would leave an empty package.json
+			await tempFile.sync();
+		} finally {
+			await tempFile.close();
+		}
+		await fs.rename(tempPath, realPath);
 	} catch (error) {
+		// best-effort cleanup of the temp file; ignore cleanup failures so the
+		// original write error is the one that surfaces
+		if (tempPath) {
+			await fs.rm(tempPath, { force: true }).catch(() => {});
+		}
 		console.error(`Failed to write package.json at ${packageJsonPath}`);
 		throw error;
 	}


### PR DESCRIPTION
## Summary

`updatePackageJson` previously rewrote `package.json` in place with a plain `fs.writeFile`, which truncates the file before writing the new contents. Any concurrent reader — a bundler resolving the package mid-build, a dev server, or a build tool capturing task outputs — could catch that window and observe an empty or partially-written `package.json`.

This bit us in practice: a downstream monorepo's remote build cache captured a truncated (empty) `package.json` as the official output of the exports-generation task and replayed it to every subsequent build, breaking unrelated CI runs with a confusing `JSONError: File is empty` far from the actual cause. A sub-millisecond race, bottled by the cache and handed out to everyone after.

## Fix

The write now follows the standard atomic-write pattern (same shape as `write-file-atomic`):

1. `realpath` the target, so a symlinked `package.json` is written through to its real file (matching the old `writeFile` behavior) and the temp file lands on the same filesystem as the target
2. write the new contents to a unique `.package.json.<hex>.tmp` in the same directory
3. `chmod` the temp file to the original file's mode (a fresh file would otherwise reset to `0o666 & ~umask`)
4. `fsync`, so a crash can't persist the rename ahead of the file data
5. `rename` over the target — atomic on the same filesystem, so readers only ever see complete old or complete new contents

On failure the temp file is cleaned up and the original `package.json` is left untouched. `dryRun` behavior is unchanged.

Perf cost is ~1–7ms per write (dominated by `fsync`; the high end is macOS `F_FULLFSYNC`), once per CLI invocation — and in watch mode only on debounced runs whose exports actually changed.

## Test plan

- [x] 7 new tests: concurrent readers never observe empty/partial content (50 writes against a hammering read loop), no temp-file litter, permission preservation, write-through of a symlinked `package.json`, `dryRun` writes nothing, original untouched when the directory isn't writable, and temp-file cleanup when the rename fails
- [x] The cleanup test is mutation-verified: deleting the cleanup line makes it fail
- [x] Full suite passes (114 tests), plus `tsc --noEmit`, `oxlint`, and `oxfmt --check`
- [x] Patch changeset included